### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/jrmybtlr/usemods/security/code-scanning/45](https://github.com/jrmybtlr/usemods/security/code-scanning/45)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only installs dependencies and runs tests, it does not require write permissions. We will set `contents: read` as the minimal permission required for the workflow to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
